### PR TITLE
Fix NVMe total capacity in smartctl dashboard

### DIFF
--- a/dashboards/dist/dashboards/smartctl.json
+++ b/dashboards/dist/dashboards/smartctl.json
@@ -1678,7 +1678,7 @@
       "repeatDirection": "h",
       "targets": [
         {
-          "expr": "sum by (model_name, device, instance) (smartctl_device_nvme_capacity_bytes{instance=~\"$instance\", job=\"$job\"} * on(device, instance) group_left(model_name) smartctl_device{instance=~\"$instance\", job=\"$job\", serial_number=~\"$serial_number\"})",
+          "expr": "sum by (model_name, device, instance) (smartctl_device_nvme_capacity_bytes{instance=~\"$instance\", job=\"$job\"} * on(device, instance) group_left(model_name) smartctl_device{instance=~\"$instance\", job=\"$job\", serial_number=~\"$serial_number\"}) or (smartctl_device_capacity_bytes{instance=~\"$instance\", job=\"$job\"} * on(device, instance) group_left(model_name) smartctl_device{instance=~\"$instance\", job=\"$job\", serial_number=~\"$serial_number\", protocol=\"NVMe\"})",
           "refId": "A",
           "format": "time_series",
           "legendFormat": "{{ model_name }} ({{ instance }}/{{ device }})",


### PR DESCRIPTION
The way NVMe capacity was implemented [1] in the exporter, `smartctl_device_nvme_capacity_bytes` only exists if the device has multiple namespaces. If there is a single namespace (like in most consumer scenarios) only `smartctl_device_capacity_bytes` exists.

This commit fixes the query to join both. 

[1] https://github.com/prometheus-community/smartctl_exporter/pull/154