### PR TITLE
Fix power on duration query in smartctl dashboard

### DIFF
--- a/dashboards/dist/dashboards/smartctl.json
+++ b/dashboards/dist/dashboards/smartctl.json
@@ -1462,7 +1462,7 @@
       "repeatDirection": "h",
       "targets": [
         {
-          "expr": "sum by (model_name, device, instance) (increase(smartctl_device_power_on_seconds{instance=~\"$instance\", job=\"$job\"} * on(device, instance) group_left(model_name) smartctl_device{instance=~\"$instance\", job=\"$job\", serial_number=~\"$serial_number\"}))",
+          "expr": "sum by (model_name, device, instance) (smartctl_device_power_on_seconds{instance=~\"$instance\", job=\"$job\"} * on(device, instance) group_left(model_name) smartctl_device{instance=~\"$instance\", job=\"$job\", serial_number=~\"$serial_number\"})",
           "refId": "A",
           "format": "time_series",
           "legendFormat": "{{ model_name }} ({{ instance }}/{{ device }})",


### PR DESCRIPTION
Without a time range like smartctl_device_power_on_seconds[1h] this query isn't valid promql because increase() needs a range.

But increase isn't necessary at all as Grafana will plot the timeseries correctly.

After the fix:
![image](https://github.com/user-attachments/assets/49d712ce-992e-4aa7-abc8-0519dbe91aef)
